### PR TITLE
$.every('minute', function() { … })

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ These are all valid calls:
     $.after("50sec", function() { ... });       // 50 seconds
     $.after(7, "mins", function() { ... });     // 7 minutes
     $.after("33", "hours", function() { ... }); // 33 hours
+    $.after("minute", function() { ... });      // 1 minute
 ```
 
 `$.every`, for creating intervals, has the same exact syntax as `$.after`.

--- a/lib/jquery.chrono.js
+++ b/lib/jquery.chrono.js
@@ -29,6 +29,7 @@ var jQueryChrono;
    *    $.after("9.7", function() { ... }); // 9.7 milliseconds
    *    $.after("50sec", function() { ... }); // 50 seconds
    *    $.after("33", "hours", function() { ... }); // 33 hours
+   *    $.after("minute", function() { ... }); // 1 minute
    * </pre>
    * Valid time units include: 
    * <strong>millisecond, second, minute, hour, & day</strong><br />
@@ -130,6 +131,9 @@ jQueryChrono = (function() {
   function parse_delay(parsed, args) {
     if (typeof args[0] === "string") {
       parsed.delay = parseFloat(args[0], 10);
+      if (isNaN(parsed.delay)) {
+        parsed.delay = 1;
+      }
     } else {
       parsed.delay = args[0];
     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -182,6 +182,14 @@ module("valid arguments");
     strictEqual(args.callback, fn, "recognizes function");
   });
   
+  test("accepts a only unit and a callback", function() {
+    var delay = 1, units = "minute", fn = $.noop,
+        args = jQueryChrono.create_timer(units, fn);
+    strictEqual(args.delay, delay, "recognizes delay");
+    strictEqual(args.units, units, "recognizes unit");
+    strictEqual(args.callback, fn, "recognizes function");
+  });
+  
 module("timer calculation");
   
   test("returns a number for when the new timer should run at", function() {


### PR DESCRIPTION
More nicw syntax sugar and human words. In normal world we say “check every second”, not “check every 1 second”. So it will be more nice to have syntax like:

```
$.every('minute', function() { … })
```

I add test for it and add sample in README and code docs. But I didn’t know, how update `.min.js` version and `doc/`.
